### PR TITLE
composer: adding missing dependency to navitia-profiler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     ],
     "require": {
         "canaltp/sam-core-bridge-bundle": "^1.0",
+        "canaltp/navitia-profiler-bundle": "~0.0",
         "symfony/translation": "2.6.*",
         "symfony/security": "2.6.*"
     },


### PR DESCRIPTION
# Description

This PR fixes missing dependency problem during NMM installation.

## Issue (optional)

```
[Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]
  The service "navitia_component" has a dependency on a non-existent service "navitia_profiler".

grep -r navitia_profiler vendor/canaltp/
vendor/canaltp/nmm-portal-bundle/Resources/config/services.yml:        arguments: ['@navitia_profiler']
```

## Pull Request type (optional)

This is a bug fix.

## How to test

Do a new installation of NMM portal.

