### PR TITLE
composer: add missing dependency for navitia-component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     "require": {
         "canaltp/sam-core-bridge-bundle": "^1.0",
         "canaltp/navitia-profiler-bundle": "~0.0",
+        "canaltp/navitia" : "~1.2",
         "symfony/translation": "2.6.*",
         "symfony/security": "2.6.*"
     },


### PR DESCRIPTION
# Description

This PR fixes missing dependency problem during NMM installation.

## Issue (optional)

```
[Symfony\Component\Debug\Exception\ClassNotFoundException]
  Attempted to load class "ServiceFacade" from namespace "Navitia\Component\Service".
  Did you forget a "use" statement for another namespace?

grep -r ServiceFacade vendor/canaltp/
vendor/canaltp/nmm-portal-bundle/Resources/config/services.yml:    navitia_component.class: Navitia\Component\Service\ServiceFacade
vendor/canaltp/nmm-portal-bundle/Services/Navitia.php:     * @return ServiceFacade Navitia Component Facade
```

## Pull Request type (optional)

This is a bug fix.

## How to test

Do a new installation of NMM portal.

