### PR TITLE
Checks the instance of connected user to allow to use multiple authentification systems

### DIFF
--- a/Services/CustomerTranslator.php
+++ b/Services/CustomerTranslator.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
-use CanaltTP\SamEcoreUserManagerBundle\Entity\User;
+use CanalTP\SamEcoreUserManagerBundle\Entity\User;
 
 /**
  * CustomerTranslator.(Overload Symfony\Component\Translation\Translator)
@@ -25,11 +25,12 @@ class CustomerTranslator extends Translator implements TranslatorInterface, Tran
             if ($this->customerId === null && $token->getUser() != 'anon.') {
                 $this->customerId = $token->getUser()->getCustomer()->getIdentifier();
             }
-
-            if ($domain === null && $this->customerId !== null && $this->catalogues[$locale]->has((string) $id, $this->customerId)) {
-                $domain = $this->customerId;
-            }
         }
+        
+        if ($domain === null && $this->customerId !== null && $this->catalogues[$locale]->has((string) $id, $this->customerId)) {
+            $domain = $this->customerId;
+        }
+        
         return ($domain);
     }
 

--- a/Services/CustomerTranslator.php
+++ b/Services/CustomerTranslator.php
@@ -8,6 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
+use CanaltTP\SamEcoreUserManagerBundle\Entity\User;
 
 /**
  * CustomerTranslator.(Overload Symfony\Component\Translation\Translator)
@@ -20,14 +21,15 @@ class CustomerTranslator extends Translator implements TranslatorInterface, Tran
     {
         $token = $this->container->get('security.context')->getToken();
 
-        if ($this->customerId === null && $token instanceof TokenInterface && $token->getUser() != 'anon.') {
-            $this->customerId = $token->getUser()->getCustomer()->getIdentifier();
-        }
+        if ($token instanceof TokenInterface && $token->getUser() instanceof User) { 
+            if ($this->customerId === null && $token->getUser() != 'anon.') {
+                $this->customerId = $token->getUser()->getCustomer()->getIdentifier();
+            }
 
-        if ($domain === null && $this->customerId !== null && $this->catalogues[$locale]->has((string) $id, $this->customerId)) {
-            $domain = $this->customerId;
+            if ($domain === null && $this->customerId !== null && $this->catalogues[$locale]->has((string) $id, $this->customerId)) {
+                $domain = $this->customerId;
+            }
         }
-
         return ($domain);
     }
 


### PR DESCRIPTION
# Description

When we use multiple authentification systems who are not based on CanaltTP\SamEcoreUserManagerBundle\Entity\User, the service "translator", throws an exception because it call an undefined method getIdentifier() on user object obtained by the security token.

This PR corrects the problem by checking the instance of user object obtained by security token.

## Pull Request type (optional)

This is a bug fix

## How to test

Here are the following steps to test this pull request:
- Adds a new authentification system based on new user entity without the propertie 'identifier'
- Authenticate a user with new system and try to translate a string

## Team reviewers (optional)

Mention here the people who should review your PR
