### PR TITLE
Add Sam core routing to keep inheritance

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,3 +1,6 @@
+sam_business_inherit:
+    resource: "@CanalTPSamCoreBundle/Resources/config/routing.yml"
+
 canal_tp_sam_homepage:
     pattern:  /
     defaults: { _controller: CanalTPSamCoreBundle:Sam:index }

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "canaltp/sam-core-bridge-bundle": "^1.0",
+        "canaltp/sam-core-bundle": "^1.4",
         "canaltp/navitia-profiler-bundle": "~0.0",
         "canaltp/navitia" : "~1.2",
         "symfony/translation": "2.6.*",


### PR DESCRIPTION
# Description

This PR fixes an issue on routing import for NmmPortalBundle, missing all the inheritance from SamCore.
This was patched with an explicit import in global routing in NMM.

This PR will allow us to simplify the routing in the NMM solution.

Needs CanalTP/SamCoreBundle#37

## Pull Request type (optional)

This is a bug fix

## How to test

Here are the following steps to test this pull request:

- see CanalTP/NMM PR for installation and testing

## Team reviewers

NMM guilde members