### PR TITLE
Fix dependencies to allow 2.8 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
         "canaltp/sam-core-bundle": "^1.4",
         "canaltp/navitia-profiler-bundle": "~0.0",
         "canaltp/navitia" : "~1.2",
-        "symfony/translation": "2.6.*",
-        "symfony/security": "2.6.*"
+        "symfony/translation": "~2.6",
+        "symfony/security": "~2.6"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.*",


### PR DESCRIPTION
# Description

This PR fixes an issue with the upgrade to Symfony 2.8.

## Pull Request type

This is a bug fix

## How to test

To test it, just try to upgrade your NMM to Symfony 2.8 and run composer update

## Team reviewers

NMM guilde

