### PR TITLE
[Customer] Go direct to edit page

### DIFF
--- a/Features/Scenarios/Customer/list.feature
+++ b/Features/Scenarios/Customer/list.feature
@@ -2,11 +2,7 @@ Feature: Customer List
 
     Background:
       Given I am logged in as Administrator
-
-    Scenario: Show page link
-      When I am on "/admin/customer"
-      Then I should see an "#show-link" element
-
+      
     Scenario: Edit page link
       When I am on "/admin/customer"
       Then I should see an "#edit-btn" element

--- a/Features/Scenarios/Customer/show.feature
+++ b/Features/Scenarios/Customer/show.feature
@@ -4,8 +4,7 @@ Feature: Show customer
       Given I am logged in as Administrator
 
     Scenario: Show page link
-      When I am on "/admin/customer"
-      And I follow "CanalTP"
+      When I am on "/admin/customer/1/show"
       Then I should see "CanalTP" in the "#title" element
       And I should see "Liste des clients"
       And I should see "Editer"

--- a/Resources/views/Customer/list.html.twig
+++ b/Resources/views/Customer/list.html.twig
@@ -28,7 +28,7 @@
     {% endif %}
     {% for customer in customers %}
         <tr class="customer-row" customer-id="{{ customer.id }}">
-            <td><a id="show-link" href="{{ path('sam_customer_show', { 'id': customer.id }) }}">{{ customer.name }}</a></td>
+            <td><a id="edit-link" href="{{ path('sam_customer_edit', { 'id': customer.id }) }}">{{ customer.name }}</a></td>
             <td><img src="{{ customer.getWebLogoPath }}" class="logo-customer-small" alt="{{ customer.name }} logo"/></td>
             <td>{{ customer.created.format('d/m/Y') }}</td>
             <td class="action">
@@ -43,7 +43,10 @@
                     <ul class="dropdown-menu pull-right" role="menu">
                         <li>
                             <a class="danger" href="{{ path('sam_customer_listtokens', { 'id': customer.id }) }}">
-                                <span class="glyphicon glyphicon-check array"></span> {{'global.actions.listtokens'|trans}}
+                                <span class="glyphicon glyphicon-barcode array"></span> {{'global.actions.listtokens'|trans}}
+                            </a>
+                            <a class="danger" href="{{ path('sam_customer_show', { 'id': customer.id }) }}">
+                                <span class="glyphicon glyphicon-question-sign array"></span> {{ customer.name }} show page
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
# Description

Tired to pass through empty 'show' page when you want edit ?
This PR go direct to edit page form clients's list

## How to test

Here are the following steps to test this pull request:

- Connected as Administrator
- go to clients list page
- got direct to edit page :)