### PR TITLE
Refs #BOT_146 Purge duplicate perimeter updated.

### DIFF
--- a/Form/Type/NavitiaEntityType.php
+++ b/Form/Type/NavitiaEntityType.php
@@ -87,7 +87,7 @@ class NavitiaEntityType extends AbstractType
                         $selectedPerims[$key] = $perimeter;
                     }
                }
-               $data['perimeters'] = $selectedPerims;
+               $data['perimeters'] = array_values($selectedPerims);
                $event->setData($data);
            }
         };

--- a/Form/Type/NavitiaEntityType.php
+++ b/Form/Type/NavitiaEntityType.php
@@ -76,13 +76,15 @@ class NavitiaEntityType extends AbstractType
         );
         $purgeDuplicates = function (FormEvent $event) {
             $data = $event->getData();
+
             if (isset($data['perimeters'])) {
-                $selectedPerims = array();
-                $selectedPerimsId = array();
-                foreach ($data['perimeters'] as $perim) {
-                    if (!in_array($perim['external_network_id'], $selectedPerimsId)){
-                        $selectedPerimsId[] = $perim['external_network_id'];
-                        $selectedPerims[] = $perim;
+                $selectedPerims = [];
+
+                foreach ($data['perimeters'] as $perimeter) {
+                    $key = $perimeter['external_coverage_id'] . '_' . $perimeter['external_network_id'];
+
+                    if (!array_key_exists($key, $selectedPerims)) {
+                        $selectedPerims[$key] = $perimeter;
                     }
                }
                $data['perimeters'] = $selectedPerims;


### PR DESCRIPTION
# Description

This PR update logical for purge duplicate perimeters

see BOT-146

## How to test

* You doesn't should have duplicate coverage / network in perimeter list
* You can have same network in different coverage.