### PR TITLE
Enable edit customer even with a non existent coverage

### DIFF
--- a/Form/Type/PerimeterType.php
+++ b/Form/Type/PerimeterType.php
@@ -9,6 +9,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormError;
 use Doctrine\ORM\EntityRepository;
 
 /**
@@ -66,8 +67,10 @@ class PerimeterType extends AbstractType
             $data = $event->getData();
             $form = $event->getForm();
             if (!is_null($data) && $this->withPerimeters) {
-                $externalCoverageId = (is_array($data) ? $data['external_coverage_id'] : $data->getExternalCoverageId());
-                $externalNetworkId = (is_array($data) ? $data['external_network_id'] : $data->getExternalNetworkId());
+                $externalCoverageId = (is_array($data) ?
+                    $data['external_coverage_id'] : $data->getExternalCoverageId());
+                $externalNetworkId = (is_array($data) ?
+                    $data['external_network_id'] : $data->getExternalNetworkId());
 
                 if (in_array($externalCoverageId, $this->coverages)) {
                     $form->remove('external_network_id');
@@ -80,9 +83,19 @@ class PerimeterType extends AbstractType
                             $externalNetworkId,
                             array(
                                 'auto_initialize' => false,
+                                'empty_value' => 'global.please_choose',
                                 'choices' => $networks
                             )
                         )
+                    );
+                    if (!array_key_exists($externalNetworkId, $networks)) {
+                        $form->get('external_network_id')->addError(
+                            new FormError('customer.network.undefined', null, ['%network%' => $externalNetworkId])
+                        );
+                    }
+                } else {
+                    $form->get('external_coverage_id')->addError(
+                        new FormError('customer.coverage.undefined', null, ['%coverage%' => $externalCoverageId])
                     );
                 }
             }

--- a/Form/Type/PerimeterType.php
+++ b/Form/Type/PerimeterType.php
@@ -69,21 +69,22 @@ class PerimeterType extends AbstractType
                 $externalCoverageId = (is_array($data) ? $data['external_coverage_id'] : $data->getExternalCoverageId());
                 $externalNetworkId = (is_array($data) ? $data['external_network_id'] : $data->getExternalNetworkId());
 
-                $form->remove('external_network_id');
-                $networks = $this->navitia->getNetWorks($externalCoverageId);
+                if (in_array($externalCoverageId, $this->coverages)) {
+                    $form->remove('external_network_id');
+                    $networks = $this->navitia->getNetWorks($externalCoverageId);
 
-
-                $form->add(
-                    $formFactory->createNamed(
-                        'external_network_id',
-                        'choice',
-                        $externalNetworkId,
-                        array(
-                            'auto_initialize' => false,
-                            'choices' => $networks
+                    $form->add(
+                        $formFactory->createNamed(
+                            'external_network_id',
+                            'choice',
+                            $externalNetworkId,
+                            array(
+                                'auto_initialize' => false,
+                                'choices' => $networks
+                            )
                         )
-                    )
-                );
+                    );
+                }
             }
         };
 

--- a/Form/Type/PerimeterType.php
+++ b/Form/Type/PerimeterType.php
@@ -71,7 +71,7 @@ class PerimeterType extends AbstractType
                     $data['external_coverage_id'] : $data->getExternalCoverageId());
                 $externalNetworkId = (is_array($data) ?
                     $data['external_network_id'] : $data->getExternalNetworkId());
-
+                // Enable edit customer even with a non existent coverage
                 if (in_array($externalCoverageId, $this->coverages)) {
                     $form->remove('external_network_id');
                     $networks = $this->navitia->getNetWorks($externalCoverageId);
@@ -89,11 +89,13 @@ class PerimeterType extends AbstractType
                         )
                     );
                     if (!array_key_exists($externalNetworkId, $networks)) {
+                        // Add message on old network selected
                         $form->get('external_network_id')->addError(
                             new FormError('customer.network.undefined', null, ['%network%' => $externalNetworkId])
                         );
                     }
                 } else {
+                    // Add message on old coverage selected
                     $form->get('external_coverage_id')->addError(
                         new FormError('customer.coverage.undefined', null, ['%coverage%' => $externalCoverageId])
                     );

--- a/Resources/public/css/main.css
+++ b/Resources/public/css/main.css
@@ -434,3 +434,15 @@ li.craue_formflow_current_step {
 .ie8 input {
     font-family: Arial;
 }
+
+/* form select infos errors */
+ul.help-block {
+    padding-left: 0;
+}
+.help-block li{
+    list-style: none;
+    padding:.8em;
+    border: dashed 1px #d43f3a;
+    background: #efefef;
+    color: black;
+}

--- a/Resources/translations/messages.fr.yml
+++ b/Resources/translations/messages.fr.yml
@@ -4,3 +4,7 @@ customer:
     list:
         action:
             edit: Editer
+    coverage:
+        undefined: %coverage% n'existe plus
+    network:
+        undefined: %network% n'existe plus


### PR DESCRIPTION
# Description

This PR enable the edition of a customer who have an old coverage in order to change / delete it

## Issue

Issue link: BOT-52

## How to test

Here are the following steps to test this pull request:

- You must have a client set with a coverage who doesn't exist (to do this, you could change it in your database)
- Edit this client
- Delete, or change the coverage
