### PR TITLE
Adding constraints on client delete in public schema

### DIFF
--- a/Migrations/pdo_pgsql/Version003.php
+++ b/Migrations/pdo_pgsql/Version003.php
@@ -14,25 +14,29 @@ class Version003 extends AbstractMigration
         return self::VERSION;
     }
 
-    /**
-     * Update / create constraints on customer / user tables
-     *
-     * @param Schema $schema
-     */
     public function up(Schema $schema)
     {
-        $this->addSql('ALTER TABLE public.t_user_usr
-          ADD CONSTRAINT fk_customer_user FOREIGN KEY (cus_id)
-            REFERENCES public.tr_customer_cus(cus_id)
-            ON UPDATE CASCADE ON DELETE CASCADE'
-        );
+        $this->addSql('
+          ALTER TABLE public.t_user_usr
+          ADD CONSTRAINT fk_customer_user 
+          FOREIGN KEY (cus_id)
+          REFERENCES public.tr_customer_cus (cus_id)
+          ON DELETE CASCADE;');
 
-        $this->addSql('ALTER TABLE public.tj_user_role_ur
+        $this->addSql('
+          ALTER TABLE public.t_perimeter_per
+          ADD CONSTRAINT fk_customer_perimeter 
+          FOREIGN KEY (nav_id)
+          REFERENCES public.t_navitia_entity_nav (nav_id)
+          ON DELETE CASCADE;');
+
+        $this->addSql('
+          ALTER TABLE public.tj_user_role_ur
           DROP CONSTRAINT fk_cc9b191bc69d3fb,
-          ADD CONSTRAINT fk_cc9b191bc69d3fb FOREIGN KEY (usr_id)
-          REFERENCES public.t_user_usr (usr_id) MATCH SIMPLE
-          ON UPDATE CASCADE ON DELETE CASCADE'
-        );
+          ADD CONSTRAINT fk_cc9b191bc69d3fb 
+          FOREIGN KEY (usr_id)
+          REFERENCES public.t_user_usr (usr_id)
+          ON DELETE CASCADE;');
 
         $this->addSql('
           ALTER TABLE public.tj_customer_application_cap
@@ -83,21 +87,21 @@ class Version003 extends AbstractMigration
           ON DELETE CASCADE;');
     }
 
-    /**
-     * Resets constraints on customer / user tables
-     *
-     * @param Schema $schema
-     */
     public function down(Schema $schema)
     {
-        $this->addSql('ALTER TABLE public.tj_user_role_ur
+        $this->addSql('
+          ALTER TABLE public.tj_user_role_ur
           DROP CONSTRAINT fk_cc9b191bc69d3fb,
-          ADD CONSTRAINT fk_cc9b191bc69d3fb FOREIGN KEY (usr_id)
-          REFERENCES public.t_user_usr (usr_id) MATCH SIMPLE
-          ON UPDATE NO ACTION ON DELETE NO ACTION'
-        );
+          ADD CONSTRAINT fk_cc9b191bc69d3fb 
+          FOREIGN KEY (usr_id)
+          REFERENCES public.t_user_usr (usr_id);');
 
-        $this->addSql('ALTER TABLE public.t_user_usr
+        $this->addSql('
+          ALTER TABLE public.t_perimeter_per
+          DROP CONSTRAINT fk_customer_perimeter;');
+
+        $this->addSql('
+          ALTER TABLE public.t_user_usr
           DROP CONSTRAINT fk_customer_user'
         );
 

--- a/Migrations/pdo_pgsql/Version003.php
+++ b/Migrations/pdo_pgsql/Version003.php
@@ -34,6 +34,53 @@ class Version003 extends AbstractMigration
           ON UPDATE CASCADE ON DELETE CASCADE'
         );
 
+        $this->addSql('
+          ALTER TABLE public.tj_customer_application_cap
+          DROP CONSTRAINT fk_9425a57f19eb6921, 
+          ADD CONSTRAINT fk_9425a57f19eb6921 
+          FOREIGN KEY (customer_id) 
+          REFERENCES public.tr_customer_cus (cus_id) 
+          ON DELETE CASCADE;');
+
+        $this->addSql('
+          ALTER TABLE public.tj_customer_application_cap
+          DROP CONSTRAINT fk_9425a57f3e030acd, 
+          ADD CONSTRAINT fk_9425a57f3e030acd 
+          FOREIGN KEY (application_id) 
+          REFERENCES public.tr_application_app (app_id) 
+          ON DELETE CASCADE;');
+
+        $this->addSql('
+          ALTER TABLE public.t_navitia_token_nat
+          DROP CONSTRAINT fk_356e8dadf03a7216, 
+          ADD CONSTRAINT fk_356e8dadf03a7216 
+          FOREIGN KEY (nav_id) 
+          REFERENCES public.t_navitia_entity_nav (nav_id) 
+          ON DELETE CASCADE;');
+
+        $this->addSql('
+          ALTER TABLE public.t_role_rol
+          DROP CONSTRAINT fk_6ed6a71f7987212d, 
+          ADD CONSTRAINT fk_6ed6a71f7987212d 
+          FOREIGN KEY (app_id) 
+          REFERENCES public.tr_application_app (app_id) 
+          ON DELETE CASCADE;');
+
+        $this->addSql('
+          ALTER TABLE public.tr_customer_cus
+          DROP CONSTRAINT fk_784fec5fdb6a43b2, 
+          ADD CONSTRAINT fk_784fec5fdb6a43b2 
+          FOREIGN KEY (cus_navitia_entity) 
+          REFERENCES public.t_navitia_entity_nav (nav_id) 
+          ON DELETE CASCADE;');
+
+        $this->addSql('
+          ALTER TABLE public.tj_user_role_ur
+          DROP CONSTRAINT fk_cc9b191b4bab96c, 
+          ADD CONSTRAINT fk_cc9b191b4bab96c 
+          FOREIGN KEY (rol_id) 
+          REFERENCES public.t_role_rol (rol_id) 
+          ON DELETE CASCADE;');
     }
 
     /**
@@ -53,5 +100,47 @@ class Version003 extends AbstractMigration
         $this->addSql('ALTER TABLE public.t_user_usr
           DROP CONSTRAINT fk_customer_user'
         );
+
+        $this->addSql('
+          ALTER TABLE public.tj_customer_application_cap
+          DROP CONSTRAINT fk_9425a57f19eb6921, 
+          ADD CONSTRAINT fk_9425a57f19eb6921 
+          FOREIGN KEY (customer_id) 
+          REFERENCES public.tr_customer_cus (cus_id);');
+
+        $this->addSql('
+          ALTER TABLE public.tj_customer_application_cap
+          DROP CONSTRAINT fk_9425a57f3e030acd, 
+          ADD CONSTRAINT fk_9425a57f3e030acd 
+          FOREIGN KEY (application_id) 
+          REFERENCES public.tr_application_app (app_id);');
+
+        $this->addSql('
+          ALTER TABLE public.t_navitia_token_nat
+          DROP CONSTRAINT fk_356e8dadf03a7216, 
+          ADD CONSTRAINT fk_356e8dadf03a7216 
+          FOREIGN KEY (nav_id) 
+          REFERENCES public.t_navitia_entity_nav (nav_id);');
+
+        $this->addSql('
+          ALTER TABLE public.t_role_rol
+          DROP CONSTRAINT fk_6ed6a71f7987212d, 
+          ADD CONSTRAINT fk_6ed6a71f7987212d 
+          FOREIGN KEY (app_id) 
+          REFERENCES public.tr_application_app (app_id);');
+
+        $this->addSql('
+          ALTER TABLE public.tr_customer_cus
+          DROP CONSTRAINT fk_784fec5fdb6a43b2, 
+          ADD CONSTRAINT fk_784fec5fdb6a43b2 
+          FOREIGN KEY (cus_navitia_entity) 
+          REFERENCES public.t_navitia_entity_nav (nav_id);');
+
+        $this->addSql('
+          ALTER TABLE public.tj_user_role_ur
+          DROP CONSTRAINT fk_cc9b191b4bab96c, 
+          ADD CONSTRAINT fk_cc9b191b4bab96c 
+          FOREIGN KEY (rol_id) 
+          REFERENCES public.t_role_rol (rol_id);');
     }
 }

--- a/Migrations/pdo_pgsql/Version003.php
+++ b/Migrations/pdo_pgsql/Version003.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace CanalTP\NmmPortalBundle\Migrations\pdo_pgsql;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Migrations\AbstractMigration;
+
+class Version003 extends AbstractMigration
+{
+    const VERSION = '0.0.3';
+
+    public function getName()
+    {
+        return self::VERSION;
+    }
+
+    /**
+     * Update / create constraints on customer / user tables
+     *
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE public.t_user_usr
+          ADD CONSTRAINT fk_customer_user FOREIGN KEY (cus_id)
+            REFERENCES public.tr_customer_cus(cus_id)
+            ON UPDATE CASCADE ON DELETE CASCADE'
+        );
+
+        $this->addSql('ALTER TABLE public.tj_user_role_ur
+          DROP CONSTRAINT fk_cc9b191bc69d3fb,
+          ADD CONSTRAINT fk_cc9b191bc69d3fb FOREIGN KEY (usr_id)
+          REFERENCES public.t_user_usr (usr_id) MATCH SIMPLE
+          ON UPDATE CASCADE ON DELETE CASCADE'
+        );
+
+    }
+
+    /**
+     * Resets constraints on customer / user tables
+     *
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE public.tj_user_role_ur
+          DROP CONSTRAINT fk_cc9b191bc69d3fb,
+          ADD CONSTRAINT fk_cc9b191bc69d3fb FOREIGN KEY (usr_id)
+          REFERENCES public.t_user_usr (usr_id) MATCH SIMPLE
+          ON UPDATE NO ACTION ON DELETE NO ACTION'
+        );
+
+        $this->addSql('ALTER TABLE public.t_user_usr
+          DROP CONSTRAINT fk_customer_user'
+        );
+    }
+}

--- a/Migrations/pdo_pgsql/Version003.php
+++ b/Migrations/pdo_pgsql/Version003.php
@@ -25,7 +25,7 @@ class Version003 extends AbstractMigration
 
         $this->addSql('
           ALTER TABLE public.t_perimeter_per
-          ADD CONSTRAINT fk_customer_perimeter 
+          ADD CONSTRAINT fk_navitia_perimeter 
           FOREIGN KEY (nav_id)
           REFERENCES public.t_navitia_entity_nav (nav_id)
           ON DELETE CASCADE;');


### PR DESCRIPTION
# Description

This PR adds constraints on public schema in order to handle client remove

## Issue (optional)

Issue link: BOT-454
https://github.com/CanalTP/NMM/issues/341

## Pull Request type (optional)

This is a new feature

## How to test

Here are the following steps to test this pull request:

- run migration from the root ```php app/console claroline:migration:upgrade CanalTPNmmPortalBundle --target=farthest```
- Remove a client from the table public.tr_customer_cus
- relevant records from tables  ```public.tj_user_role_ur``` and ```public.t_user_usr```