### PR TITLE
Symfony3 compatible

### DIFF
--- a/Controller/CustomerController.php
+++ b/Controller/CustomerController.php
@@ -151,7 +151,7 @@ class CustomerController extends \CanalTP\SamCoreBundle\Controller\AbstractContr
         try {
             $networks = $navitia->getNetworks($externalCoverageId);
             asort($networks);
-        } catch(\Navitia\Component\Exception\NavitiaException $e) {
+        } catch (\Navitia\Component\Exception\NavitiaException $e) {
             $response->setData(array('status' => $status));
             $response->setStatusCode($status);
 
@@ -181,7 +181,7 @@ class CustomerController extends \CanalTP\SamCoreBundle\Controller\AbstractContr
         $navitia->setToken($token);
         try {
             $networks = $navitia->getNetworks($externalCoverageId);
-        } catch(\Navitia\Component\Exception\NavitiaException $e) {
+        } catch (\Navitia\Component\Exception\NavitiaException $e) {
             $response->setData(array('status' => $status));
             $response->setStatusCode($status);
 

--- a/Entity/Customer.php
+++ b/Entity/Customer.php
@@ -2,10 +2,11 @@
 
 namespace CanalTP\NmmPortalBundle\Entity;
 
-use CanalTP\SamCoreBundle\Entity\CustomerInterface;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use CanalTP\SamCoreBundle\Entity\CustomerInterface;
+use CanalTP\SamCoreBundle\Slugify;
 
 class Customer extends \CanalTP\SamCoreBundle\Entity\AbstractEntity implements CustomerInterface
 {
@@ -162,9 +163,8 @@ class Customer extends \CanalTP\SamCoreBundle\Entity\AbstractEntity implements C
 
     protected function setNameCanonical($name)
     {
-        $slug = new \CanalTP\SamCoreBundle\Slugify();
+        $this->nameCanonical = Slugify::format($name, '_');
 
-        $this->nameCanonical = $slug->slugify($name, '_');
         return $this;
     }
 

--- a/Entity/NavitiaEntity.php
+++ b/Entity/NavitiaEntity.php
@@ -4,6 +4,8 @@ namespace CanalTP\NmmPortalBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
+use CanalTP\SamCoreBundle\Slugify;
+
 
 /**
  * NavitiaEntity
@@ -134,8 +136,7 @@ class NavitiaEntity extends \CanalTP\SamCoreBundle\Entity\AbstractEntity
      */
     protected function setNameCanonical($name)
     {
-        $slug = new \CanalTP\SamCoreBundle\Slugify();
-        $this->nameCanonical = $slug->slugify($name);
+        $this->nameCanonical = Slugify::format($name);
 
         return $this;
     }

--- a/Form/Type/CustomerApplicationType.php
+++ b/Form/Type/CustomerApplicationType.php
@@ -4,7 +4,7 @@ namespace CanalTP\NmmPortalBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\File;
@@ -40,12 +40,7 @@ class CustomerApplicationType extends AbstractType
         );
     }
 
-    public function getName()
-    {
-        return 'customer_application';
-    }
-
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(

--- a/Form/Type/CustomerType.php
+++ b/Form/Type/CustomerType.php
@@ -4,7 +4,7 @@ namespace CanalTP\NmmPortalBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\File;
@@ -104,12 +104,7 @@ class CustomerType extends \CanalTP\SamCoreBundle\Form\Type\CustomerType
         $this->addApplicationsField($builder);
     }
 
-    public function getName()
-    {
-        return 'customer';
-    }
-
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(

--- a/Form/Type/CustomerType.php
+++ b/Form/Type/CustomerType.php
@@ -38,8 +38,7 @@ class CustomerType extends \CanalTP\SamCoreBundle\Form\Type\CustomerType
         ApplicationToCustomerApplicationTransformer $applicationsTransformer,
         ApplicationToCustomerApplicationTransformerWithToken $applicationsTransformerWithToken,
         $withTyr
-    )
-    {
+    ) {
         $this->em = $em;
         $this->coverages = $coverages;
         $this->navitia = $navitia;
@@ -50,8 +49,7 @@ class CustomerType extends \CanalTP\SamCoreBundle\Form\Type\CustomerType
 
     private function addApplicationsField(FormBuilderInterface $builder)
     {
-        if ($this->withTyr)
-        {
+        if ($this->withTyr) {
             $builder->add(
                 'applications',
                 'entity',
@@ -59,7 +57,7 @@ class CustomerType extends \CanalTP\SamCoreBundle\Form\Type\CustomerType
                     'label' => 'customer.applications',
                     'multiple' => true,
                     'class' => 'CanalTPSamCoreBundle:Application',
-                    'query_builder' => function(EntityRepository $er) {
+                    'query_builder' => function (EntityRepository $er) {
                         return $er->createQueryBuilder('cli')
                             ->orderBy('cli.name', 'ASC');
                     },

--- a/Form/Type/NavitiaEntityType.php
+++ b/Form/Type/NavitiaEntityType.php
@@ -4,7 +4,7 @@ namespace CanalTP\NmmPortalBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\File;
@@ -95,12 +95,7 @@ class NavitiaEntityType extends AbstractType
         $builder->addEventListener(FormEvents::PRE_SUBMIT, $purgeDuplicates);
     }
 
-    public function getName()
-    {
-        return 'customer';
-    }
-
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(

--- a/Form/Type/PerimeterType.php
+++ b/Form/Type/PerimeterType.php
@@ -4,7 +4,7 @@ namespace CanalTP\NmmPortalBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Form\FormEvent;
@@ -106,12 +106,7 @@ class PerimeterType extends AbstractType
         $builder->addEventListener(FormEvents::PRE_SET_DATA, $callback);
     }
 
-    public function getName()
-    {
-        return 'perimeter';
-    }
-
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(

--- a/Migrations/pdo_pgsql/Version002.php
+++ b/Migrations/pdo_pgsql/Version002.php
@@ -32,4 +32,3 @@ class Version002 extends AbstractMigration
         $this->addSql("UPDATE tr_application_app SET app_bundle_name = '' WHERE app_canonical_name='samcore'");
     }
 }
-

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -50,7 +50,6 @@ services:
 
     sam_core.role_listener:
         class: %sam_core.role_listener.class%
-        arguments: ['@sam_core.slugify']
         tags:
             -  { name: doctrine.entity_listener }
 

--- a/Services/CustomerManager.php
+++ b/Services/CustomerManager.php
@@ -14,16 +14,16 @@ class CustomerManager extends \CanalTP\SamCoreBundle\Services\CustomerManager
     protected $repository = null;
     protected $navitiaTokenManager = null;
 
-    public function __construct(ObjectManager $om,
+    public function __construct(
+        ObjectManager $om,
         $navitiaTokenManager,
         ApplicationFinder $applicationFinder
-    )
-    {
+    ) {
         parent::__construct($om, $navitiaTokenManager, $applicationFinder);
         $this->repository = $this->om->getRepository('CanalTPNmmPortalBundle:Customer');
     }
 
-    public function findOneBy(Array $filters)
+    public function findOneBy(array $filters)
     {
         return ($this->repository->findOneBy($filters));
     }

--- a/Services/CustomerTranslator.php
+++ b/Services/CustomerTranslator.php
@@ -21,7 +21,7 @@ class CustomerTranslator extends Translator implements TranslatorInterface, Tran
     {
         $token = $this->container->get('security.context')->getToken();
 
-        if ($token instanceof TokenInterface && $token->getUser() instanceof User) { 
+        if ($token instanceof TokenInterface && $token->getUser() instanceof User) {
             if ($this->customerId === null && $token->getUser() != 'anon.') {
                 $this->customerId = $token->getUser()->getCustomer()->getIdentifier();
             }

--- a/Services/NavitiaTokenManager.php
+++ b/Services/NavitiaTokenManager.php
@@ -299,7 +299,7 @@ class NavitiaTokenManager
     {
         try {
             $this->user = $this->findUser($email);
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             throw new \Exception('Navitia error : ' . $e->getMessage());
         }
 
@@ -322,7 +322,7 @@ class NavitiaTokenManager
         $this->samNavitia->setToken($token);
         try {
             $networks = $this->samNavitia->getNetWorks($externalCoverageId);
-        } catch(\Navitia\Component\Exception\NavitiaException $e) {
+        } catch (\Navitia\Component\Exception\NavitiaException $e) {
             return $response;
         }
 

--- a/Services/PerimeterManager.php
+++ b/Services/PerimeterManager.php
@@ -7,10 +7,9 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
  * Description of PerimeterManager
- *
- * @author Kévin Ziemianski
  */
-class PerimeterManager {
+class PerimeterManager
+{
 
     private $repository = null;
     private $om = null;
@@ -28,7 +27,7 @@ class PerimeterManager {
                 return ($perimeter);
             }
         }
-        throw new AccessDeniedException();        
+        throw new AccessDeniedException();
     }
 
     public function findOneByExternalNetworkId($customer, $externalNetworkId)
@@ -36,7 +35,6 @@ class PerimeterManager {
         $perimeters = $customer->getPerimeters();
 
         return ($this->getPerimeterByExtenalNetworkId($perimeters, $externalNetworkId));
-
     }
 
     public function findOneByCustomerIdAndExternalNetworkId($customerId, $externalNetworkId)

--- a/Tests/Units/CustomerTranslatorTest.php
+++ b/Tests/Units/CustomerTranslatorTest.php
@@ -61,7 +61,7 @@ class CustomerTranslatorTest extends TranslatorTest
         $container
             ->expects($this->any())
             ->method('get')
-            ->will($this->returnCallback(function($arg) use ($loader) {
+            ->will($this->returnCallback(function ($arg) use ($loader) {
                 if ($arg == 'security.context') {
                     return ($this->securityContext);
                 }

--- a/Twig/TokenExtension.php
+++ b/Twig/TokenExtension.php
@@ -35,10 +35,4 @@ class TokenExtension extends \Twig_Extension
 
         return true;
     }
-
-    public function getName()
-    {
-        return 'token';
-    }
-
 }


### PR DESCRIPTION
fix 
```
+----+-------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| #  | Usage                                                                                                       | Line | Comment                                                                       |
+----+-------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/nmm-portal-bundle/Form/Type/PerimeterType.php                                                                             |
+----+-------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| 1  | Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface                       | 114  | since version 2.6, to be removed in 3.0. Use {@link OptionsResolver} instead. |
| 2  | Overriding deprecated method CanalTP\NmmPortalBundle\Form\Type\PerimeterType->getName()                     | 109  | Deprecated since Symfony 2.8, to be removed in Symfony 3.0.                   |
|    |                                                                                                             |      |  Use the fully-qualified class name of the type instead.                      |
| 3  | Overriding deprecated method CanalTP\NmmPortalBundle\Form\Type\PerimeterType->setDefaultOptions()           | 114  | since version 2.7, to be renamed in 3.0.                                      |
|    |                                                                                                             |      |  Use the method configureOptions instead. This method will be                 |
|    |                                                                                                             |      |  added to the FormTypeInterface with Symfony 3.0.                             |
+----+-------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/nmm-portal-bundle/Form/Type/CustomerApplicationType.php                                                                   |
+----+-------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| 4  | Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface                       | 48   | since version 2.6, to be removed in 3.0. Use {@link OptionsResolver} instead. |
| 5  | Overriding deprecated method CanalTP\NmmPortalBundle\Form\Type\CustomerApplicationType->getName()           | 43   | Deprecated since Symfony 2.8, to be removed in Symfony 3.0.                   |
|    |                                                                                                             |      |  Use the fully-qualified class name of the type instead.                      |
| 6  | Overriding deprecated method CanalTP\NmmPortalBundle\Form\Type\CustomerApplicationType->setDefaultOptions() | 48   | since version 2.7, to be renamed in 3.0.                                      |
|    |                                                                                                             |      |  Use the method configureOptions instead. This method will be                 |
|    |                                                                                                             |      |  added to the FormTypeInterface with Symfony 3.0.                             |
+----+-------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/nmm-portal-bundle/Form/Type/CustomerType.php                                                                              |
+----+-------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| 7  | Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface                       | 112  | since version 2.6, to be removed in 3.0. Use {@link OptionsResolver} instead. |
| 8  | Overriding deprecated method CanalTP\NmmPortalBundle\Form\Type\CustomerType->getName()                      | 107  | Deprecated since Symfony 2.8, to be removed in Symfony 3.0.                   |
|    |                                                                                                             |      |  Use the fully-qualified class name of the type instead.                      |
| 9  | Overriding deprecated method CanalTP\NmmPortalBundle\Form\Type\CustomerType->setDefaultOptions()            | 112  | since version 2.7, to be renamed in 3.0.                                      |
|    |                                                                                                             |      |  Use the method configureOptions instead. This method will be                 |
|    |                                                                                                             |      |  added to the FormTypeInterface with Symfony 3.0.                             |
+----+-------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/nmm-portal-bundle/Form/Type/NavitiaEntityType.php                                                                         |
+----+-------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| 10 | Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface                       | 103  | since version 2.6, to be removed in 3.0. Use {@link OptionsResolver} instead. |
| 11 | Overriding deprecated method CanalTP\NmmPortalBundle\Form\Type\NavitiaEntityType->getName()                 | 98   | Deprecated since Symfony 2.8, to be removed in Symfony 3.0.                   |
|    |                                                                                                             |      |  Use the fully-qualified class name of the type instead.                      |
| 12 | Overriding deprecated method CanalTP\NmmPortalBundle\Form\Type\NavitiaEntityType->setDefaultOptions()       | 103  | since version 2.7, to be renamed in 3.0.                                      |
|    |                                                                                                             |      |  Use the method configureOptions instead. This method will be                 |
|    |                                                                                                             |      |  added to the FormTypeInterface with Symfony 3.0.                             |
+----+-------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/nmm-portal-bundle/Twig/TokenExtension.php                                                                                 |
+----+-------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| 13 | Overriding deprecated method CanalTP\NmmPortalBundle\Twig\TokenExtension->getName()                         | 39   | since 1.26 (to be removed in 2.0), not used anymore internally                |
| 14 | Overriding deprecated method CanalTP\NmmPortalBundle\Twig\TokenExtension->getName()                         | 39   | since 1.26 (to be removed in 2.0), not used anymore internally                |
+----+-------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
```

Relates to https://jira.kisio.org/browse/GN-60

:exclamation: dependency to https://github.com/CanalTP/SamCoreBundle/pull/51