### PR TITLE
Add new button 'Désactiver' and persist object in database

### DIFF
--- a/Controller/CustomerController.php
+++ b/Controller/CustomerController.php
@@ -117,7 +117,7 @@ class CustomerController extends \CanalTP\SamCoreBundle\Controller\AbstractContr
      *
      * @return CanalTP\NmmPortalBundle\Entity\Customer
      */
-    public function findCustomerById ($id) {
+    private function findCustomerById ($id) {
         $customer = $this->getDoctrine()
             ->getManager()
             ->getRepository('CanalTPNmmPortalBundle:Customer')

--- a/Controller/CustomerController.php
+++ b/Controller/CustomerController.php
@@ -104,7 +104,7 @@ class CustomerController extends \CanalTP\SamCoreBundle\Controller\AbstractContr
                     );
                 }
                 $customerManager = $this->container->get('sam_core.customer');
-                $customerManager->archiveCustomer($customer);
+                $customerManager->archive($customer);
                 $this->addFlashMessage('success', $this->get('translator')->trans('customer.archive.flash.success', ['%customer%' => $customer->getName()]));
             }
 

--- a/Controller/CustomerController.php
+++ b/Controller/CustomerController.php
@@ -58,6 +58,74 @@ class CustomerController extends \CanalTP\SamCoreBundle\Controller\AbstractContr
         );
     }
 
+    public function archiveAction(Request $request, $id)
+    {
+        $this->isGranted('BUSINESS_MANAGE_CLIENT');
+
+        $form = $this->createArchiveForm($id);
+
+        if ($request->getMethod() == 'GET') {
+            $customer = $this->getDoctrine()
+                ->getManager()
+                ->getRepository('CanalTPNmmPortalBundle:Customer')
+                ->find($id);
+
+            if (is_null($customer)) {
+                return $this->render(
+                    'CanalTPNmmPortalBundle:Customer:error.html.twig',
+                    array(
+                        'error' => 'customer.archive.error'
+                    )
+                );
+            }
+
+            return $this->render(
+                'CanalTPNmmPortalBundle:Customer:archive.html.twig',
+                array(
+                    'customer' => $customer,
+                    'archive_form' => $form->createView(),
+                )
+            );
+        } else {
+            $form->bind($request);
+
+            if ($form->isValid()) {
+                $customer = $this->getDoctrine()
+                    ->getManager()
+                    ->getRepository('CanalTPNmmPortalBundle:Customer')
+                    ->find($id);
+
+                if (is_null($customer)) {
+                    return $this->render(
+                        'CanalTPNmmPortalBundle:Customer:error.html.twig',
+                        array(
+                            'error' => 'customer.archive.error'
+                        )
+                    );
+                }
+                $customerManager = $this->container->get('sam_core.customer');
+                $customerManager->archiveCustomer($customer);
+                $this->addFlashMessage('success', $this->get('translator')->trans('customer.archive.flash.success', ['%customer%' => $customer->getName()]));
+            }
+
+            return $this->redirect($this->generateUrl('sam_customer_list'));
+        }
+    }
+
+    /**
+     * Creates a form to archive a Customer entity by id.
+     *
+     * @param mixed $id The customer id
+     *
+     * @return Symfony\Component\Form\Form The form
+     */
+    private function createArchiveForm($id)
+    {
+        return $this->createFormBuilder(array('id' => $id))
+            ->add('id', 'hidden')
+            ->getForm();
+    }
+
     private function dispatchEvent($form, $type)
     {
         $event = new CustomerEvent($form->getData());

--- a/Controller/CustomerController.php
+++ b/Controller/CustomerController.php
@@ -58,18 +58,14 @@ class CustomerController extends \CanalTP\SamCoreBundle\Controller\AbstractContr
         );
     }
 
-    public function archiveAction(Request $request, $id)
+    public function archiveFormAction(Request $request, $id)
     {
         $this->isGranted('BUSINESS_MANAGE_CLIENT');
 
         $form = $this->createArchiveForm($id);
 
         if ($request->getMethod() == 'GET') {
-            $customer = $this->getDoctrine()
-                ->getManager()
-                ->getRepository('CanalTPNmmPortalBundle:Customer')
-                ->find($id);
-
+            $customer = $this->findCustomerById($id);
             if (is_null($customer)) {
                 return $this->render(
                     'CanalTPNmmPortalBundle:Customer:error.html.twig',
@@ -78,7 +74,6 @@ class CustomerController extends \CanalTP\SamCoreBundle\Controller\AbstractContr
                     )
                 );
             }
-
             return $this->render(
                 'CanalTPNmmPortalBundle:Customer:archive.html.twig',
                 array(
@@ -86,30 +81,49 @@ class CustomerController extends \CanalTP\SamCoreBundle\Controller\AbstractContr
                     'archive_form' => $form->createView(),
                 )
             );
-        } else {
-            $form->bind($request);
-
-            if ($form->isValid()) {
-                $customer = $this->getDoctrine()
-                    ->getManager()
-                    ->getRepository('CanalTPNmmPortalBundle:Customer')
-                    ->find($id);
-
-                if (is_null($customer)) {
-                    return $this->render(
-                        'CanalTPNmmPortalBundle:Customer:error.html.twig',
-                        array(
-                            'error' => 'customer.archive.error'
-                        )
-                    );
-                }
-                $customerManager = $this->container->get('sam_core.customer');
-                $customerManager->archive($customer);
-                $this->addFlashMessage('success', $this->get('translator')->trans('customer.archive.flash.success', ['%customer%' => $customer->getName()]));
-            }
-
-            return $this->redirect($this->generateUrl('sam_customer_list'));
         }
+    }
+
+    public function saveArchiveAction (Request $request, $id)
+    {
+        $this->isGranted('BUSINESS_MANAGE_CLIENT');
+
+        $form = $this->createArchiveForm($id);
+
+        $form->bind($request);
+
+        if ($form->isValid()) {
+            $customer = $this->findCustomerById($id);
+            if (is_null($customer)) {
+                return $this->render(
+                    'CanalTPNmmPortalBundle:Customer:error.html.twig',
+                    array(
+                        'error' => 'customer.archive.error'
+                    )
+                );
+            }
+            $customerManager = $this->container->get('sam_core.customer');
+            $customerManager->archive($customer);
+            $this->addFlashMessage('success', $this->get('translator')->trans('customer.archive.flash.success', ['%customer%' => $customer->getName()]));
+        }
+
+        return $this->redirect($this->generateUrl('sam_customer_list'));
+    }
+
+    /**
+     * Find a Customer by id.
+     *
+     * @param mixed $id The customer id
+     *
+     * @return CanalTP\NmmPortalBundle\Entity\Customer
+     */
+    public function findCustomerById ($id) {
+        $customer = $this->getDoctrine()
+            ->getManager()
+            ->getRepository('CanalTPNmmPortalBundle:Customer')
+            ->find($id);
+
+        return $customer;
     }
 
     /**

--- a/DataFixtures/ORM/FixturesCustomer.php
+++ b/DataFixtures/ORM/FixturesCustomer.php
@@ -32,6 +32,10 @@ class FixturesCustomer extends AbstractFixture implements OrderedFixtureInterfac
         $this->createCustomer($om, 'CanalTP', 'nmm-ihm@canaltp.fr', 'canaltp');
         $this->addPerimeterToCustomer($om, 'fr-bou', 'network:CGD', 'customer-canaltp');
 
+        $this->createCustomer($om, 'Realtime Test', 'fahmi.laajimi@canaltp.fr', 'realtime_test');
+        $this->addPerimeterToCustomer($om, 'jdr', 'network:DUA014', 'customer-realtime_test');
+
+        $this->addCustomerToApplication($om, 'app-samcore', 'customer-realtime_test', $navitiaToken);
         $this->addCustomerToApplication($om, 'app-samcore', 'customer-canaltp', $navitiaToken);
 
         $om->flush();

--- a/Features/Context/FeatureContext.php
+++ b/Features/Context/FeatureContext.php
@@ -19,4 +19,12 @@ class FeatureContext extends MinkContext
         $this->fillField('password', 'admin');
         $this->pressButton('Connexion');
     }
+
+    /**
+     * @Given /^I wait (\d+) seconds$/
+     */
+    public function wait($seconds)
+    {
+        sleep($seconds);
+    }
 }

--- a/Features/Scenarios/Customer/list.feature
+++ b/Features/Scenarios/Customer/list.feature
@@ -5,5 +5,16 @@ Feature: Customer List
       
     Scenario: Edit page link
       When I am on "/admin/customer"
-      Then I should see an "#edit-btn" element
+      Then I should see an ".edit-btn" element
       And I should see an ".archive" element
+
+    Scenario: Deactivate a customer
+      When I am on "/admin/customer"
+      And I press "show-toggled-actions-2"
+      And I wait 2 seconds
+      And I follow "archive-2"
+      And I wait 2 seconds
+      Then I should see "Désactiver le client"
+      When I press "Désactiver"
+      Then I should be on "/admin/customer"
+      And I should see an ".alert-success" element

--- a/Features/Scenarios/Customer/list.feature
+++ b/Features/Scenarios/Customer/list.feature
@@ -6,3 +6,4 @@ Feature: Customer List
     Scenario: Edit page link
       When I am on "/admin/customer"
       Then I should see an "#edit-btn" element
+      And I should see an ".archive" element

--- a/Features/Scenarios/Customer/list.feature
+++ b/Features/Scenarios/Customer/list.feature
@@ -1,20 +1,27 @@
 Feature: Customer List
 
-    Background:
-      Given I am logged in as Administrator
-      
-    Scenario: Edit page link
-      When I am on "/admin/customer"
-      Then I should see an ".edit-btn" element
-      And I should see an ".archive" element
+  Scenario: Edit page link
+    Given I am logged in as Administrator
+    When I am on "/admin/customer"
+    Then I should see an ".edit-btn" element
+    And I should see an ".archive" element
 
-    Scenario: Deactivate a customer
-      When I am on "/admin/customer"
-      And I press "show-toggled-actions-2"
-      And I wait 2 seconds
-      And I follow "archive-2"
-      And I wait 2 seconds
-      Then I should see "Désactiver le client"
-      When I press "Désactiver"
-      Then I should be on "/admin/customer"
-      And I should see an ".alert-success" element
+  Scenario: Check if deactivate link exist
+    Given I am logged in as Administrator
+    And I am on "/admin/customer"
+    When I press "show-toggled-actions-2"
+    And I wait 2 seconds
+    And I follow "archive-2"
+    And I wait 2 seconds
+    Then I should see "Désactiver le client"
+
+  Scenario: Deactivate a customer
+    Given I am logged in as Administrator
+    And I am on "/admin/customer"
+    And I press "show-toggled-actions-2"
+    And I wait 2 seconds
+    And I follow "archive-2"
+    And I wait 2 seconds
+    When I press "Désactiver"
+    Then I should be on "/admin/customer"
+    And I should see an ".alert-success" element

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -46,3 +46,8 @@ sam_customer_regeneratealltokens:
 sam_customer_listtokens:
     pattern:  /customer/{id}/tokens
     defaults: { _controller: CanalTPSamCoreBundle:Customer:listTokens }
+
+sam_customer_archive:
+    pattern:  /customer/{id}/archive
+    defaults: { _controller: CanalTPSamCoreBundle:Customer:archive }
+

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -48,6 +48,10 @@ sam_customer_listtokens:
     defaults: { _controller: CanalTPSamCoreBundle:Customer:listTokens }
 
 sam_customer_archive:
-    pattern:  /customer/{id}/archive
-    defaults: { _controller: CanalTPSamCoreBundle:Customer:archive }
+    pattern:  /customer/{id}/archive/form
+    defaults: { _controller: CanalTPSamCoreBundle:Customer:archiveForm }
+
+sam_customer_archive_save:
+    pattern:  /customer/{id}/archive/save
+    defaults: { _controller: CanalTPSamCoreBundle:Customer:saveArchive }
 

--- a/Resources/translations/messages.en.yml
+++ b/Resources/translations/messages.en.yml
@@ -1,0 +1,18 @@
+customer:
+    token:
+        placeholder: Token of navitia
+    list:
+        action:
+            edit: Edit
+    coverage:
+        undefined: %coverage% undefined
+    network:
+        undefined: %network% undefined
+    archive:
+        title: Deactivate customer
+        confirm: Are you sure you want to do this action?
+        error: Unable to find Customer entity.
+        flash:
+            success: Customer %customer% has been deactivated
+    actions:
+        archive: Deactivate

--- a/Resources/translations/messages.fr.yml
+++ b/Resources/translations/messages.fr.yml
@@ -8,3 +8,11 @@ customer:
         undefined: %coverage% n'existe plus
     network:
         undefined: %network% n'existe plus
+    archive:
+        title: Désactiver le client
+        confirm: Êtes-vous sûr de vouloir faire cette action ?
+        error: Impossible de trouver l'entité client.
+        flash:
+            success: Le client %customer% a été désactivé
+    actions:
+        archive: Désactiver

--- a/Resources/views/Customer/archive.html.twig
+++ b/Resources/views/Customer/archive.html.twig
@@ -1,0 +1,22 @@
+{% extends ['::modal.html.twig', 'CanalTPSamCoreBundle::modal.html.twig'] %}
+
+{% block modal_title %}
+    {{'customer.archive.title'|trans}}
+{% endblock %}
+
+{% block modal_body %}
+    <p>{{'customer.archive.confirm'|trans}}</p>
+{% endblock %}
+
+{% block open_form %}
+<form action="{{ path('sam_customer_archive', { 'id': customer.id }) }}" method="post">
+    <input type="hidden" name="_method" value="DELETE" />
+    {% endblock %}
+
+    {% block modal_actions %}
+    {{ form_widget(archive_form) }}
+    <button class="btn btn-danger" type="submit">
+        <span class="glyphicon glyphicon-trash"></span> {{'customer.actions.archive'|trans}}
+    </button>
+</form>
+{% endblock %}

--- a/Resources/views/Customer/archive.html.twig
+++ b/Resources/views/Customer/archive.html.twig
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block open_form %}
-<form action="{{ path('sam_customer_archive', { 'id': customer.id }) }}" method="post">
+<form action="{{ path('sam_customer_archive_save', { 'id': customer.id }) }}" method="post">
     <input type="hidden" name="_method" value="DELETE" />
     {% endblock %}
 

--- a/Resources/views/Customer/error.html.twig
+++ b/Resources/views/Customer/error.html.twig
@@ -1,0 +1,18 @@
+{% extends ['::modal.html.twig', 'CanalTPSamCoreBundle::modal.html.twig'] %}
+
+{% block modal_title %}
+    {{'customer.archive.title'|trans}}
+{% endblock %}
+
+{% block modal_body %}
+    <p>{{error|trans}}</p>
+{% endblock %}
+
+{% block open_form %}
+<form>
+    <input type="hidden" name="_method" value="" />
+{% endblock %}
+
+ {% block modal_actions %}
+</form>
+{% endblock %}

--- a/Resources/views/Customer/list.html.twig
+++ b/Resources/views/Customer/list.html.twig
@@ -52,7 +52,7 @@
                             </a>
                         </li>
                         <li>
-                            <a class="danger" href="{{ path('sam_customer_archive', { 'id': customer.id }) }}" data-toggle="modal" data-target="#base-modal">
+                            <a class="danger archive" href="{{ path('sam_customer_archive', { 'id': customer.id }) }}" data-toggle="modal" data-target="#base-modal">
                                 <span class="glyphicon glyphicon-trash"></span> {{'customer.actions.archive'|trans}}
                             </a>
                         </li>

--- a/Resources/views/Customer/list.html.twig
+++ b/Resources/views/Customer/list.html.twig
@@ -51,6 +51,11 @@
                                 <span class="glyphicon glyphicon-barcode"></span> {{'global.actions.listtokens'|trans}}
                             </a>
                         </li>
+                        <li>
+                            <a class="danger" href="{{ path('sam_customer_archive', { 'id': customer.id }) }}" data-toggle="modal" data-target="#base-modal">
+                                <span class="glyphicon glyphicon-trash"></span> {{'customer.actions.archive'|trans}}
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </td>

--- a/Resources/views/Customer/list.html.twig
+++ b/Resources/views/Customer/list.html.twig
@@ -33,10 +33,10 @@
             <td>{{ customer.created.format('d/m/Y') }}</td>
             <td class="action">
                 <div class="btn-group">
-                    <a id="edit-btn" class="btn btn-default" href="{{ path('sam_customer_edit', { 'id': customer.id }) }}">
+                    <a class="edit-btn btn btn-default" href="{{ path('sam_customer_edit', { 'id': customer.id }) }}">
                         <span class="glyphicon glyphicon-edit array"></span> {{'customer.list.action.edit'|trans}}
                     </a>
-                    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                    <button id="show-toggled-actions-{{ customer.id }}" type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                         <span class="caret"></span>
                         <span class="sr-only">{{'ctp_core.toggle_menu'|trans}}</span>
                     </button>
@@ -52,7 +52,7 @@
                             </a>
                         </li>
                         <li>
-                            <a class="danger archive" href="{{ path('sam_customer_archive', { 'id': customer.id }) }}" data-toggle="modal" data-target="#base-modal">
+                            <a id="archive-{{ customer.id }}" class="danger archive" href="{{ path('sam_customer_archive', { 'id': customer.id }) }}" data-toggle="modal" data-target="#base-modal">
                                 <span class="glyphicon glyphicon-trash"></span> {{'customer.actions.archive'|trans}}
                             </a>
                         </li>

--- a/Services/CustomerManager.php
+++ b/Services/CustomerManager.php
@@ -60,7 +60,7 @@ class CustomerManager extends \CanalTP\SamCoreBundle\Services\CustomerManager
         $this->om->flush();
     }
 
-    public function archiveCustomer($customer)
+    public function archive($customer)
     {
         $customer->setLocked(true);
         $usersOfCustomer = $customer->getUsers();

--- a/Services/CustomerManager.php
+++ b/Services/CustomerManager.php
@@ -60,6 +60,17 @@ class CustomerManager extends \CanalTP\SamCoreBundle\Services\CustomerManager
         $this->om->flush();
     }
 
+    public function archiveCustomer($customer)
+    {
+        $customer->setLocked(true);
+        $usersOfCustomer = $customer->getUsers();
+        foreach ($usersOfCustomer as $user) {
+            $user->setLocked(true);
+        }
+        $this->om->persist($customer);
+        $this->om->flush();
+    }
+
     protected function createCustomerApplicationRelation($customer, Application $application)
     {
         $customerApplication = new CustomerApplication();


### PR DESCRIPTION
# Description

This PR:
 - Add new button Deactivate in admin > customer > list > actions
 - Persist action in database
## Issue

Issue link: BOT-1178

## Pull Request type

This is a new feature

## How to test

Here are the following steps to test this pull request:

- Go to admin > customer > list 
- You should see new button Deactivate in actions column
- Deactivate a customer
- Then in database you should see the customer and it's users has been deactivated (public.tr_customer_cus.cus_locked=true, public.t_user_usr.usr_locked=true)
