### PR TITLE
Fix composer version

### DIFF
--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | \
-    php -- --install-dir=/usr/bin/ --filename=composer \
+    php -- --install-dir=/usr/bin/ --filename=composer --version=1.10.16 \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
         unzip \
         git \


### PR DESCRIPTION
# Description

This PR fix the problem of the library ocramius/package-versions (that need php 7.4 with composer2)
